### PR TITLE
fix: Revert to relative asset paths in index.html

### DIFF
--- a/conversation-analyzer/frontend/index.html
+++ b/conversation-analyzer/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Conversation Analyzer</title>
-    <link rel="stylesheet" href="/rec/style.css">
+    <link rel="stylesheet" href="style.css">
 </head>
 <body>
     <h1>Conversation Analyzer</h1>
@@ -23,6 +23,6 @@
       <div id="tasks-container"></div>
     </div>
 
-    <script src="/rec/main.js"></script>
+    <script src="main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This commit reverts the asset paths for `style.css` and `main.js` in `index.html` back to relative paths.

Absolute paths were added based on an incorrect assumption about the deployment URL. Given the new information that the frontend is served from `/rec/conversation-analyzer/frontend/`, relative paths are the correct and most robust solution.