### PR TITLE
fix: Use absolute path for upload folder

### DIFF
--- a/conversation-analyzer/backend/main.py
+++ b/conversation-analyzer/backend/main.py
@@ -38,7 +38,7 @@ def init_db_command():
     print("Initialized the database.")
 
 # --- Static File Serving ---
-UPLOAD_FOLDER = 'uploads'
+UPLOAD_FOLDER = os.path.join(basedir, 'uploads')
 if not os.path.exists(UPLOAD_FOLDER):
     os.makedirs(UPLOAD_FOLDER)
 


### PR DESCRIPTION
This commit modifies the backend to use an absolute path for the audio upload directory. This avoids ambiguity with relative paths and should resolve file permission errors when the application is run by a different user (e.g., `www-data`) in a production environment.