### PR TITLE
refactor: Revert to relative paths for assets and API calls

### DIFF
--- a/conversation-analyzer/frontend/index.html
+++ b/conversation-analyzer/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Conversation Analyzer</title>
-    <link rel="stylesheet" href="/rec/conversation-analyzer/frontend/style.css">
+    <link rel="stylesheet" href="style.css">
 </head>
 <body>
     <h1>Conversation Analyzer</h1>
@@ -32,6 +32,6 @@
       <div id="tasks-container"></div>
     </div>
 
-    <script src="/rec/conversation-analyzer/frontend/main.js"></script>
+    <script src="main.js"></script>
 </body>
 </html>

--- a/conversation-analyzer/frontend/main.js
+++ b/conversation-analyzer/frontend/main.js
@@ -1,5 +1,3 @@
-const API_BASE_PATH = '/rec';
-
 document.addEventListener('DOMContentLoaded', () => {
     // --- Tab Switching ---
     const tabs = document.querySelectorAll('.tab-button');
@@ -83,7 +81,7 @@ function makeTaskEditable(label) {
 // --- API Functions for Tasks ---
 async function deleteTask(taskId) {
     try {
-        await fetch(`${API_BASE_PATH}/api/tasks/${taskId}`, { method: 'DELETE' });
+        await fetch(`/api/tasks/${taskId}`, { method: 'DELETE' });
     } catch (error) {
         console.error('Error deleting task:', error);
     }
@@ -91,7 +89,7 @@ async function deleteTask(taskId) {
 
 async function updateTask(taskId, payload) {
     try {
-        await fetch(`${API_BASE_PATH}/api/tasks/${taskId}`, {
+        await fetch(`/api/tasks/${taskId}`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload),
@@ -103,7 +101,7 @@ async function updateTask(taskId, payload) {
 
 async function fetchTasks() {
     try {
-        const response = await fetch(`${API_BASE_PATH}/api/tasks`);
+        const response = await fetch('/api/tasks');
         if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
         const taskGroups = await response.json();
         renderTasks(taskGroups);
@@ -238,7 +236,7 @@ async function uploadAudio(blob) {
 
     console.log("Uploading audio file...");
     try {
-        const response = await fetch(`${API_BASE_PATH}/upload`, {
+        const response = await fetch("/upload", {
             method: "POST",
             body: formData
         });


### PR DESCRIPTION
This commit reverts the hardcoded path changes from previous commits and simplifies the application's pathing logic.

- `index.html` now uses simple relative paths for `style.css` and `main.js`.
- `main.js` now uses simple root-relative paths (e.g., `/api/tasks`) for all API calls.

This change is in preparation for a simplified reverse proxy configuration where the entire application is served from the root, making the code more portable and the deployment less complex.